### PR TITLE
Add total F1 score for decision tree classifier

### DIFF
--- a/test_decision_tree.py
+++ b/test_decision_tree.py
@@ -40,7 +40,7 @@ def test_imports():
         try:
             from sklearn.tree import DecisionTreeClassifier
             from sklearn.model_selection import train_test_split
-            from sklearn.metrics import classification_report, accuracy_score, confusion_matrix
+            from sklearn.metrics import classification_report, accuracy_score, confusion_matrix, f1_score
             print("✓ scikit-learn imports are available")
         except ImportError as e:
             print(f"⚠ scikit-learn not available: {e}")

--- a/train_decision_tree.py
+++ b/train_decision_tree.py
@@ -111,7 +111,7 @@ def train_decision_tree(
     try:
         from sklearn.tree import DecisionTreeClassifier
         from sklearn.model_selection import train_test_split
-        from sklearn.metrics import classification_report, accuracy_score, confusion_matrix
+        from sklearn.metrics import classification_report, accuracy_score, confusion_matrix, f1_score
     except ImportError:
         raise ImportError("scikit-learn is required for decision tree training. Please install it with: pip install scikit-learn")
     
@@ -137,8 +137,10 @@ def train_decision_tree(
     # Evaluate on test set
     y_pred = dt_classifier.predict(X_test)
     accuracy = accuracy_score(y_test, y_pred)
+    total_f1 = f1_score(y_test, y_pred, average='macro')
     
     print(f"\nTest Accuracy: {accuracy:.4f}")
+    print(f"Total F1 Score (macro): {total_f1:.4f}")
     print("\nClassification Report:")
     print(classification_report(y_test, y_pred))
     


### PR DESCRIPTION
Implements total F1 score calculation for decision tree classifier to improve model comparability.

- Added f1_score import from sklearn.metrics
- Calculate and display macro-averaged F1 score alongside accuracy
- Updated test imports to include f1_score

Resolves #6

Generated with [Claude Code](https://claude.ai/code)